### PR TITLE
docs(readme): change the shield link for github contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GitHub contributors](https://img.shields.io/github/contributors/kennethtegrado/kennethtegrado-portfolio-nextjs?color=%23435fff&label=Contributors&logo=Github&style=for-the-badge)
+![GitHub contributors](https://img.shields.io/github/contributors/kennethtegrado/portfolio?color=%23435fff&label=Contributors&logo=Github&style=for-the-badge)
 ![Powered by Vercel](https://img.shields.io/badge/Powered%20by-Vercel-%23435fff?style=for-the-badge&logo=vercel)
 ![Built with NEXT JS](https://img.shields.io/badge/Built%20with-Next%20JS-%23435fff?style=for-the-badge&logo=next.js)
 ![TypeScript Portfolio](https://img.shields.io/badge/Built%20with-TypeScript-%23435fff?style=for-the-badge&logo=typescript)


### PR DESCRIPTION
[DOCS] Change the Github Link for the Github Shield #3

# Description

Removed the **REPOSITORY NOT FOUND** appearing on the Github Contributors shield in the README.md file.

Fixes # 3

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

# Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
